### PR TITLE
#38 Support cucumberjs v1.1.0 api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 npm-debug.log
+
+.idea/

--- a/lib/resultsCapturer.js
+++ b/lib/resultsCapturer.js
@@ -33,13 +33,13 @@ module.exports = function () {
   });
 
   this.registerHandler('BeforeFeature', function (event, callback) {
-    feature = event.getPayloadItem('feature');
+    feature = event;
     callback();
   });
 
   this.registerHandler('AfterScenario', function (event, callback) {
     var scenarioInfo = {
-      name: event.getPayloadItem('scenario').getName(),
+      name: event.getName(),
       category: feature.getName()
     };
     stepResults.description = scenarioInfo.name;
@@ -58,15 +58,13 @@ module.exports = function () {
   });
 
   this.registerHandler('StepResult', function (event, callback) {
-    var stepResult = event.getPayloadItem('stepResult');
-
-    switch (stepResult.getStatus()) {
+    switch (event.getStatus()) {
       case Cucumber.Status.PASSED:
         stepResults.assertions.push({passed: true});
         break;
       case Cucumber.Status.FAILED:
         scenarioFailed = true;
-        var failureMessage = stepResult.getFailureException();
+        var failureMessage = event.getFailureException();
         stepResults.assertions.push({
           passed: false,
           errorMsg: failureMessage.message,
@@ -84,7 +82,7 @@ module.exports = function () {
         break;
     }
 
-    stepResults.duration += stepResult.getDuration();
+    stepResults.duration += event.getDuration();
     callback();
   });
 };

--- a/lib/resultsCapturer.js
+++ b/lib/resultsCapturer.js
@@ -27,19 +27,19 @@ module.exports = function () {
   var feature = buildFeature();
   var stepResults = buildStepResults();
 
-  this.registerHandler('BeforeFeatures', function (event, callback) {
+  this.registerHandler('BeforeFeatures', function (features, callback) {
     clearResults();
     callback();
   });
 
-  this.registerHandler('BeforeFeature', function (event, callback) {
-    feature = event;
+  this.registerHandler('BeforeFeature', function (beforeFeature, callback) {
+    feature = beforeFeature;
     callback();
   });
 
-  this.registerHandler('AfterScenario', function (event, callback) {
+  this.registerHandler('AfterScenario', function (scenario, callback) {
     var scenarioInfo = {
-      name: event.getName(),
+      name: scenario.getName(),
       category: feature.getName()
     };
     stepResults.description = scenarioInfo.name;
@@ -57,14 +57,14 @@ module.exports = function () {
     callback();
   });
 
-  this.registerHandler('StepResult', function (event, callback) {
-    switch (event.getStatus()) {
+  this.registerHandler('StepResult', function (stepResult, callback) {
+    switch (stepResult.getStatus()) {
       case Cucumber.Status.PASSED:
         stepResults.assertions.push({passed: true});
         break;
       case Cucumber.Status.FAILED:
         scenarioFailed = true;
-        var failureMessage = event.getFailureException();
+        var failureMessage = stepResult.getFailureException();
         stepResults.assertions.push({
           passed: false,
           errorMsg: failureMessage.message,
@@ -82,7 +82,7 @@ module.exports = function () {
         break;
     }
 
-    stepResults.duration += event.getDuration();
+    stepResults.duration += stepResult.getDuration();
     callback();
   });
 };


### PR DESCRIPTION
Updated resultsCapturer to use the event object as preferred by the cucumberjs v1.1.0 api (not using getPayloaditem).

 Also ignoring .idea directory in gitignore
