### PR TITLE
Enable passing a `rerun` file to `cucumberjs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,33 @@ exports.config = {
 		'path/to/feature/files/**/*.feature' // accepts a glob
 	],
   cucumberOpts: {
-	  // require step definitions
+    // require step definitions
     require: [
     	'path/to/step/definitions/**/*.steps.js' // accepts a glob
     ]
   }
 };
 ```
+
+### Passing Options to cucumberjs
+
+All of the `cucumberOpts` will be passed to `cucumberjs` as arguments.
+
+For example, to call cucumberjs with the `--strict`, `--no-colors`, and to specify custom formatters:
+
+```js
+cucumberOpts: {
+  strick: true,
+  'no-colors': true,
+  format: ['progress', 'pretty:output.txt'],
+  // ...
+}
+```
+
+The following parameters have special behavior:
+
+ * `require` - globs will be expanded to multiple `--require` arguments
+ * `rerun` - value is passed as the first argument; for use with the [rerun feature](https://github.com/cucumber/cucumber-js/blob/master/features/rerun_formatter.feature)
 
 Contributing
 ------------
@@ -44,11 +64,20 @@ Pull requests are welcome. Commits should have an appropriate message and be squ
 
 For Contributors
 ----------------
+
+Ensure that the following dependencies are installed:
+
+ * Java SDK and JRE
+ * node.js
+ * Google Chrome
+
 Clone the github repository:
 
     git clone https://github.com/mattfritz/protractor-cucumber-framework
     cd protractor-cucumber-framework
     npm install
+
+### Testing
 
 Start up a selenium server. By default, the tests expect the selenium server to be running at `http://localhost:4444/wd/hub`. A selenium server can be started with `webdriver-manager`.
 

--- a/index.js
+++ b/index.js
@@ -24,7 +24,9 @@ exports.run = function(runner, specs) {
     return q.promise(function(resolve, reject) {
       var cliArguments = convertOptionsToCliArguments(opts);
       cliArguments.push('--require', path.resolve(__dirname, 'lib', 'resultsCapturer.js'));
-      cliArguments = cliArguments.concat(specs);
+      if (!opts.rerun) {
+        cliArguments = cliArguments.concat(specs);
+      }
 
       debug('cucumber command: "' + cliArguments.join(' ') + '"');
 
@@ -47,8 +49,15 @@ exports.run = function(runner, specs) {
   function convertOptionsToCliArguments(options) {
     var cliArguments = ['node', 'cucumberjs'];
 
+    if (options.rerun) {
+      cliArguments.push(options.rerun);
+    }
+
     for (var option in options) {
       var cliArgumentValues = convertOptionValueToCliValues(option, options[option]);
+      if (option === 'rerun') {
+        continue;
+      }
 
       if (Array.isArray(cliArgumentValues)) {
         cliArgumentValues.forEach(function (value) {

--- a/package.json
+++ b/package.json
@@ -42,9 +42,9 @@
   },
   "devDependencies": {
     "chai": "^3.4.1",
-    "chai-as-promised": "^5.2.0",
+    "chai-as-promised": "^6.0.0",
     "cucumber": "^1.0.0",
     "httpster": "^1.0.1",
-    "protractor": "^3.2.0"
+    "protractor": "^4.0.9"
   }
 }

--- a/spec/@rerun.txt
+++ b/spec/@rerun.txt
@@ -1,0 +1,1 @@
+spec/cucumber/success.feature:7

--- a/spec/cucumber/failure.feature
+++ b/spec/cucumber/failure.feature
@@ -1,0 +1,19 @@
+Feature: Running Cucumber with Protractor
+  As a user of Protractor
+  I should be able to use Cucumber
+  to run my E2E tests
+
+  @failing
+  Scenario: Report failures
+    Given I go on "index.html"
+    Then the title should equal "Failing scenario 1"
+
+  @failing @rerun
+  Scenario: Reporting multiple failures
+    Given I go on "index.html"
+    Then the title should equal "Failing scenario 2"
+
+  @strict
+  Scenario: Missing step definition
+    Given I go on "index.html"
+    Then this step is not defined

--- a/spec/cucumber/success.feature
+++ b/spec/cucumber/success.feature
@@ -3,7 +3,7 @@ Feature: Running Cucumber with Protractor
   I should be able to use Cucumber
   to run my E2E tests
 
-  @dev
+  @dev @rerun
   Scenario: Running Cucumber with Protractor
     Given I run Cucumber with Protractor
     Then it should still do normal tests
@@ -13,18 +13,3 @@ Feature: Running Cucumber with Protractor
   Scenario: Wrapping WebDriver
     Given I go on "index.html"
     Then the title should equal "My AngularJS App"
-
-  @failing
-  Scenario: Report failures
-    Given I go on "index.html"
-    Then the title should equal "Failing scenario 1"
-
-  @failing
-  Scenario: Reporting multiple failures
-    Given I go on "index.html"
-    Then the title should equal "Failing scenario 2"
-
-  @strict
-  Scenario: Missing step definition
-    Given I go on "index.html"
-    Then this step is not defined

--- a/test.js
+++ b/test.js
@@ -9,6 +9,7 @@ testFailFastFastOption();
 testStrictOption();
 testUndefinedWithoutStrictOption();
 testMultiCapsOverrideBaseOptsAndCliOpts();
+testRerunOption();
 
 executor.execute();
 
@@ -47,6 +48,12 @@ function testUndefinedWithoutStrictOption() {
 
 function testMultiCapsOverrideBaseOptsAndCliOpts() {
   executor.addCommandlineTest('node_modules/protractor/bin/protractor spec/multiConf.js --cucumberOpts.tags @failing')
+   .expectExitCode(0)
+   .expectErrors([]);
+}
+
+function testRerunOption() {
+  executor.addCommandlineTest('node_modules/protractor/bin/protractor spec/cucumberConf.js --cucumberOpts.tags @rerun --cucumberOpts.rerun spec/@rerun.txt')
    .expectExitCode(0)
    .expectErrors([]);
 }


### PR DESCRIPTION
This is a relatively new feature to cucumberjs, but there was no way to pass the correct parameter to cause a rerun. I also added some documentation on how the parameters are passed to `cucumberjs`
