### PR TITLE
fix: fix undefined tags

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,9 +87,11 @@ exports.run = function(runner, specs) {
       );
 
       if (Array.isArray(cliArgumentValues)) {
-        cliArgumentValues.forEach(value =>
-          cliArguments.push('--' + option, value)
-        );
+        cliArgumentValues.forEach(value => {
+          if (value) {
+            cliArguments.push('--' + option, value);
+          }
+        });
       } else if (cliArgumentValues) {
         cliArguments.push('--' + option);
       }

--- a/index.js
+++ b/index.js
@@ -87,11 +87,9 @@ exports.run = function(runner, specs) {
       );
 
       if (Array.isArray(cliArgumentValues)) {
-        cliArgumentValues.forEach(value => {
-          if (value) {
-            cliArguments.push('--' + option, value);
-          }
-        });
+        cliArgumentValues.forEach(value =>
+          cliArguments.push('--' + option, value)
+        );
       } else if (cliArgumentValues) {
         cliArguments.push('--' + option);
       }
@@ -116,7 +114,7 @@ exports.run = function(runner, specs) {
       .map(tag => tag.replace(/~/, 'not '))
       .join(' and ');
 
-    return [converted];
+    return converted ? [converted] : '';
   }
 
   function makeFormatPathsUnique(values) {

--- a/test/cucumber/conf/cucumber3Conf.js
+++ b/test/cucumber/conf/cucumber3Conf.js
@@ -3,7 +3,7 @@ let env = require('./environment.js');
 exports.config = Object.assign({}, env, {
   cucumberOpts: {
     require: '../stepDefinitions/**/cucumber2Steps.js',
-    tags: '@cucumber3',
+    tags: '',
     format: 'summary',
     strict: true,
     'format-options': '{"colorsEnabled": false}'

--- a/test/cucumber3.spec.js
+++ b/test/cucumber3.spec.js
@@ -3,11 +3,24 @@ let util = require('./test_util');
 describe('cucumber version 3', function() {
   it('runs successful features', function() {
     return util
-      .runOne('test/cucumber/conf/cucumber3Conf.js')
+      .runOne(
+        'test/cucumber/conf/cucumber3Conf.js --cucumberOpts.tags @cucumber3'
+      )
       .cucumberVersion3()
       .expectExitCode(0)
       .expectOutput('3 scenarios (3 passed)')
       .expectErrors([])
+      .run();
+  });
+
+  it('ignores tags when the value is an empty string', function() {
+    return util
+      .runOne(
+        'test/cucumber/conf/cucumber3Conf.js --specs **/cucumber2.feature'
+      )
+      .cucumberVersion3()
+      .expectExitCode(0)
+      .expectOutput('1 scenario (1 passed)')
       .run();
   });
 });

--- a/test/output-files.spec.js
+++ b/test/output-files.spec.js
@@ -70,7 +70,7 @@ describe('output files', () => {
   });
 
   it('should handle relative paths with cucumber 3', () => {
-    let cmd = `test/cucumber/conf/cucumber3Conf.js --cucumberOpts.format json:../${LOG_FILE_NAME}.json`;
+    let cmd = `test/cucumber/conf/cucumber3Conf.js --cucumberOpts.tags @cucumber3 --cucumberOpts.format json:../${LOG_FILE_NAME}.json`;
     let packageJson = require('../package.json');
     let cwd = cucumberLoader.cwd(packageJson.cucumberConf.version3);
 

--- a/test/restart-browser.spec.js
+++ b/test/restart-browser.spec.js
@@ -3,7 +3,7 @@ let util = require('./test_util');
 describe('restart browsers between tests', function() {
   it('should run all scenarios successfully', function() {
     let cmd =
-      'test/cucumber/conf/cucumber3Conf.js --restartBrowserBetweenTests';
+      'test/cucumber/conf/cucumber3Conf.js --cucumberOpts.tags @cucumber3 --restartBrowserBetweenTests';
 
     return util
       .runOne(cmd)


### PR DESCRIPTION
Due to a change in CucumberJS 3.0.4 the `cucumberOpts.tags:''`, which results in `--tags undefined` makes CucumberJS break with `Error: empty stack`.

This fixes https://github.com/protractor-cucumber-framework/protractor-cucumber-framework/issues/113