### PR TITLE
[fix] Cucumber parallel execution does not work with protractor

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,7 +87,7 @@ exports.run = function(runner, specs) {
       );
 
       if (Array.isArray(cliArgumentValues)) {
-        cliArgumentValues.forEach(value =>
+        cliArgumentValues.forEach(function (value) {
           if (config.capabilities.shardTestFiles || config.capabilities.parallel>0) {
               if (option == 'format') {
                   var parts = value.split(':');
@@ -99,7 +99,7 @@ exports.run = function(runner, specs) {
               }
           }
           cliArguments.push('--' + option, value);
-        );
+        });
       } else if (cliArgumentValues) {
         cliArguments.push('--' + option);
       }

--- a/index.js
+++ b/index.js
@@ -88,7 +88,17 @@ exports.run = function(runner, specs) {
 
       if (Array.isArray(cliArgumentValues)) {
         cliArgumentValues.forEach(value =>
-          cliArguments.push('--' + option, value)
+          if (config.capabilities.shardTestFiles || config.capabilities.parallel>0) {
+              if (option == 'format') {
+                  var parts = value.split(':');
+                  if (typeof(parts[1]) !== 'undefined') {
+                      var featureName = specs[0].split('/').pop().split('.')[0];
+                      parts[1] = parts[1].split('/').slice(0, -1).join('/') + "/" + featureName + ".json";
+                      value = parts.join(':');
+                  }
+              }
+          }
+          cliArguments.push('--' + option, value);
         );
       } else if (cliArgumentValues) {
         cliArguments.push('--' + option);


### PR DESCRIPTION
Makes a report json for each feature file from the given specs. Will name them as for example, afeature.feature is respective to afeature.json.

For cucumber-html-reporter compatability, give your folder of json reports as the option to reportOptions.jsonDir when you run the generate function.