### PR TITLE
fix(sharding): Ensure callback resolves if run promise fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,10 @@ exports.run = function(runner, specs) {
     state.initialize(runner, results, opts.strict);
 
     return q.promise(function(resolve, reject) {
-      runCucumber(cliArgs, () => {
+      runCucumber(cliArgs, error => {
+        if (error instanceof Error) {
+          return reject(error);
+        }
         try {
           let complete = q();
 
@@ -58,7 +61,10 @@ exports.run = function(runner, specs) {
         stdout: process.stdout
       });
 
-      return cli.run().then(done);
+      return cli
+        .run()
+        .then(done)
+        .catch(done);
     } else {
       Cucumber.Cli(argv).run(done);
     }

--- a/test/cucumber/conf/cucumber4ShardedFail.js
+++ b/test/cucumber/conf/cucumber4ShardedFail.js
@@ -1,0 +1,11 @@
+let env = require('./environment.js');
+
+exports.config = Object.assign({}, env, {
+  cucumberOpts: {
+    require: [
+      '../stepDefinitions/**/cucumber4Steps.js',
+      '../hooks/**/cucumber4FailedBeforeAll.js'
+    ],
+    tags: '@dev'
+  }
+});

--- a/test/cucumber/hooks/cucumber4FailedBeforeAll.js
+++ b/test/cucumber/hooks/cucumber4FailedBeforeAll.js
@@ -1,0 +1,14 @@
+const path = require('path');
+
+const {BeforeAll} = require(path.join(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'lib',
+  'cucumberLoader'
+)).load();
+
+BeforeAll(function(callback) {
+  callback('Failed');
+});

--- a/test/fail-beforeall.spec.js
+++ b/test/fail-beforeall.spec.js
@@ -1,0 +1,14 @@
+let util = require('./test_util');
+
+describe('Exit when cucumber fails to launch', function() {
+  it('exit when sharded and cucumber fails to launch', function() {
+    let cmd =
+      'test/cucumber/conf/cucumber4ShardedFail.js --capabilities.shardTestFiles true';
+    return util
+      .runOne(cmd)
+      .cucumberVersion4()
+      .expectExitCode(100)
+      .expectErrors(['BeforeAll hook errored'])
+      .run();
+  });
+});


### PR DESCRIPTION
When running 2+ shards, if cucumber fails to launch (for example BeforeAll hook or webdriver fails) it ended up in hung state.
Added error handling and test to properly exit the execution in case of failure.