### PR TITLE
Do not add pid in format absolute windows paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,7 +132,7 @@ exports.run = function(runner, specs) {
 
   function makeFormatPathsUnique(values) {
     return toArray(values).map(function(format) {
-      let formatPathMatch = format.match(/(.+):(.+)/);
+      let formatPathMatch = format.match(/(..+):(.+)/);
       if (!formatPathMatch) return format;
 
       let pathParts = formatPathMatch[2].split('.');


### PR DESCRIPTION
Hello,

The current formatting of the report files names using the PID breaks the windows paths generated by `require.resolve`.
It leads to this kind of errors:
`E/launcher - Error: Error: Cannot find module 'C:\*\node_modules\cucumber-pretty\index.613.js'`

For example when doing:
`format: [
        require.resolve('cucumber-pretty')
]
`

I am not aware of any format name of a single letter so the fix would still add the PID to all the reports but would keep any Windows path unbroken.