### PR TITLE
[Isssue-185] Added check for undefined message.

### DIFF
--- a/lib/resultsCapturer.js
+++ b/lib/resultsCapturer.js
@@ -235,6 +235,14 @@ function commonStepFinished({
       break;
 
     case Cucumber.Status.AMBIGUOUS:
+      emitterEvent = 'testFail';
+      scenarioFailed = true;
+      stepResults.assertions.push({
+      passed: false,
+      errorMsg: exception ? exception.message : 'Ambiguous step found.',
+      stackTrace: exception ? exception.stack : undefined
+      });
+    break;
     case Cucumber.Status.FAILED:
       if (
         state.strict ||
@@ -245,8 +253,8 @@ function commonStepFinished({
         scenarioFailed = true;
         stepResults.assertions.push({
           passed: false,
-          errorMsg: exception.message,
-          stackTrace: exception.stack
+          errorMsg: exception ? exception.message : 'No Exception message found',
+          stackTrace: exception ? exception.stack : undefined
         });
       }
       break;


### PR DESCRIPTION
### If there is any ambiguous step, the process fails with below error:

× And I expand the Demo Parameters and Outputs

> 

C:\src\common-highcharts-lib-ux\node_modules\protractor-cucumber-framework\lib\resultsCapturer.js:240
**errorMsg: exception.message,
^
TypeError: ........\protractor-cucumber-framework\lib\resultsCapturer.js:52 Cannot read property 'message'**
of undefined
at commonStepFinished (C:\src\common-highcharts-lib-ux\node_modules\protractor-cucumber-framework\lib\resultsCapturer.js:240:37)
at stepResultHandler (C:\src\common-highcharts-lib-ux\node_modules\protractor-cucumber-framework\lib\resultsCapturer.js:210:5)
at ZoneDelegate.invokeTask (C:\src\common-highcharts-lib-ux\node_modules\zone.js\dist\zone-node.js:423:31) at Zone.runTask (C:\src\common-highcharts-lib-ux\node_modules\zone.js\dist\zone-node.js:195:47)
at ZoneTask.invokeTask (C:\src\common-highcharts-lib-ux\node_modules\zone.js\dist\zone-node.js:498:34)
at ZoneTask.invoke (C:\src\common-highcharts-lib-ux\node_modules\zone.js\dist\zone-node.js:487:48)
[16:01:12] E/launcher - Process exited with error code
1

### I have added a check for nullability/undefined before reading the error message.