### PR TITLE
fix: include Background objects in feature child lookup

### DIFF
--- a/lib/resultsCapturer.js
+++ b/lib/resultsCapturer.js
@@ -320,7 +320,7 @@ function computeResultsFromEventDataCollector(testCaseAttempts) {
       const featureChild =
         step && feature
           ? feature.children.find(c =>
-              c.scenario.steps.find(s => s.id === stepNodeId)
+            (c.scenario || c.background).steps.find(s => s.id === stepNodeId)
             )
           : undefined;
       const scenario = featureChild ? featureChild.scenario : undefined;


### PR DESCRIPTION
Fixes  `Cannot read property 'steps' of null"`

---

Hi there @flaviencathala 👋 

I bumped into an issue today after upgrading to CucumberJS 7 and latest of protractor-cucumber-framework.
After the test execution is completed, all specs report a warning with the error "Cannot read property 'steps' of null", and my tests fail, even if all specs are green.

Digging into the source, I noticed that the "Background" keyword breaks the report generation.
I don't know exactly how the whole library works, but including "background" along with "scenario" in the featureChild lookup worked for me.

Let me know how can I help in getting this fixed. It will probably affect others that use "Background" in test specs.